### PR TITLE
Updated Capybara version to 1.1.1 in bbq.gemspec

### DIFF
--- a/bbq.gemspec
+++ b/bbq.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "capybara",  "~> 1.0.0"
+  s.add_dependency "capybara", "~> 1.1.1"
 
   s.add_development_dependency "sqlite3",     "~> 1.3.3"
   s.add_development_dependency "rake",        "~> 0.8.7"


### PR DESCRIPTION
It'd be nice to allow running bbq with current version of Capybara, which is 1.1.1. (1.1.0 had some problems with rack-test, so it's better to avoid it).

I'm not sure if we can allow both `~> 1.0.0` and `~> 1.1.0` in .gemspec, so I propose updating dependency version to 1.1.
