### PR TITLE
Fix `:within` scope for RSpec-flavoured tests

### DIFF
--- a/lib/bbq/rspec.rb
+++ b/lib/bbq/rspec.rb
@@ -14,44 +14,36 @@ module Bbq
   end
 
   module RSpecMatchers
-    class TestUserEyes
-      def initialize(negative, *args)
-        @args, @negative = args, negative
+    extend RSpec::Matchers::DSL
+
+    matcher :see do |text|
+      chain :within do |locator|
+        @locator = locator
       end
 
-      def matches?(actual)
-        @negative ? actual.not_see?(*@args) : actual.see?(*@args)
+      match_for_should do |page|
+        if @locator
+          within(@locator) { page.see? text }
+        else
+          page.see? text
+        end
       end
 
-      def failure_message_for_should
-        "expected to #{@negative ? negative_description : positive_description}"
+      match_for_should_not do |page|
+        if @locator
+        within(@locator) { page.not_see? text }
+        else
+          page.not_see? text
+        end
       end
 
-      def failure_message_for_should_not
-        "expected to #{@negative ? positive_description : negative_description}"
+      failure_message_for_should do |page|
+        "expected to see #{text}"
       end
 
-      def description
-        @negative ? negative_description : positive_description
+      failure_message_for_should_not do |page|
+        "expected not to see #{text}"
       end
-
-      protected
-
-      def negative_description
-        "not see any of the following: #{@args.join(', ')}"
-      end
-
-      def positive_description
-        "see all of the following: #{@args.join(', ')}"
-      end
-    end
-
-    def see(*args)
-      TestUserEyes.new(false, *args)
-    end
-
-    def not_see(*args)
-      TestUserEyes.new(true, *args)
     end
   end
 
@@ -61,15 +53,11 @@ module Bbq
     include Bbq::RSpecMatchers
 
     def see!(*args)
-      args.each do |arg|
-        page.should have_content(arg)
-      end
+      see?(*args).should be_true
     end
 
     def not_see!(*args)
-      args.each do |arg|
-        page.should have_no_content(arg)
-      end
+      not_see?(*args).should be_true
     end
   end
 end

--- a/test/unit/bbq_rspec_test.rb
+++ b/test/unit/bbq_rspec_test.rb
@@ -23,7 +23,7 @@ class BbqRspecTest < Test::Unit::TestCase
       end
     RSPEC
 
-    run_cmd 'rspec -Itest/dummy/spec test/dummy/spec/acceptance/dsl_spec.rb'
+    run_cmd 'bundle exec rspec -Itest/dummy/spec test/dummy/spec/acceptance/dsl_spec.rb'
     assert_match /1 example, 0 failures/, output
   end
 
@@ -43,7 +43,7 @@ class BbqRspecTest < Test::Unit::TestCase
       end
     RSPEC
 
-    run_cmd 'rspec -Itest/dummy/spec test/dummy/spec/acceptance/capybara_matchers_spec.rb'
+    run_cmd 'bundle exec rspec -Itest/dummy/spec test/dummy/spec/acceptance/capybara_matchers_spec.rb'
     assert_match /1 example, 0 failures/, output
   end
 
@@ -58,13 +58,21 @@ class BbqRspecTest < Test::Unit::TestCase
           user = Bbq::TestUser.new
           user.visit "/miracle"
           user.should see("MIRACLE")
-          user.should not_see("BBQ")
+          user.should_not see("BBQ")
+        end
+
+        scenario 'should allow to chain matcher with within scope' do
+          user = Bbq::TestUser.new
+          user.visit '/ponycorns'
+
+          user.should see('Pink').within('#unicorns')
+          user.should_not see('Violet').within('#unicorns')
         end
       end
     RSPEC
 
-    run_cmd 'rspec -Itest/dummy/spec test/dummy/spec/acceptance/bbq_matchers_spec.rb'
-    assert_match /1 example, 0 failures/, output
+    run_cmd 'bundle exec rspec -Itest/dummy/spec test/dummy/spec/acceptance/bbq_matchers_spec.rb'
+    assert_match /2 examples, 0 failures/, output
   end
 
   def test_implicit_user_eyes
@@ -80,14 +88,24 @@ class BbqRspecTest < Test::Unit::TestCase
           user.see!("MIRACLE")
           user.not_see!("BBQ")
 
-          lambda { user.see!("BBQ") }.should raise_error
-          lambda { user.not_see!("MIRACLE") }.should raise_error
+          expect { user.see!("BBQ") }.to raise_error
+          expect { user.not_see!("MIRACLE") }.to raise_error
+        end
+
+        scenario 'should work with within option' do
+          user = Bbq::TestUser.new
+          user.visit '/ponycorns'
+          user.see! 'Pink', :within => '#unicorns'
+          user.not_see! 'Violet', :within => '#unicorns'
+
+          expect { user.see! 'Violet', :within => '#unicorns' }.to raise_error
+          expect { user.not_see! 'Pink', :within => '#unicorns' }.to raise_error
         end
       end
     RSPEC
 
-    run_cmd 'rspec -Itest/dummy/spec test/dummy/spec/acceptance/implicit_user_eyes_spec.rb'
-    assert_match /1 example, 0 failures/, output
+    run_cmd 'bundle exec rspec -Itest/dummy/spec test/dummy/spec/acceptance/implicit_user_eyes_spec.rb'
+    assert_match /2 examples, 0 failures/, output
   end
 
   def test_api_client
@@ -109,7 +127,7 @@ class BbqRspecTest < Test::Unit::TestCase
       end
     RSPEC
 
-    run_cmd 'rspec -Itest/dummy/spec test/dummy/spec/acceptance/api_spec.rb'
+    run_cmd 'bundle exec rspec -Itest/dummy/spec test/dummy/spec/acceptance/api_spec.rb'
     assert_match /1 example, 0 failures/, output
   end
 
@@ -152,7 +170,7 @@ class BbqRspecTest < Test::Unit::TestCase
       end
     RSPEC
 
-    run_cmd 'rspec -Itest/dummy/spec -Itest/support test/dummy/spec/acceptance/session_pool_spec.rb'
+    run_cmd 'bundle exec rspec -Itest/dummy/spec -Itest/support test/dummy/spec/acceptance/session_pool_spec.rb'
     assert_match /3 examples, 0 failures/, output
     drivers_created = File.readlines(@log_path).size
     assert_equal 2, drivers_created
@@ -193,7 +211,7 @@ class BbqRspecTest < Test::Unit::TestCase
       end
     RSPEC
 
-    run_cmd 'rspec -Itest/dummy/spec -Itest/support test/dummy/spec/acceptance/without_session_pool_spec.rb'
+    run_cmd 'bundle exec rspec -Itest/dummy/spec -Itest/support test/dummy/spec/acceptance/without_session_pool_spec.rb'
     assert_match /3 examples, 0 failures/, output
     drivers_created = File.readlines(@log_path).size
     assert_equal 4, drivers_created


### PR DESCRIPTION
[Fixes #31]
- Rewrite `see` matcher
- Allow to use `:within` option in RSpec version
  of Bbq::TestUser#see! and Bbq::TestUser#not_see!
