### PR TITLE
Client should propagate NoMethodErrors from tested application

### DIFF
--- a/lib/bbq/test_client.rb
+++ b/lib/bbq/test_client.rb
@@ -15,18 +15,19 @@ module Bbq
     HTTP_METHODS.each do |method|
       class_eval <<-RUBY
         def #{method}(path, params = {}, headers = {})
-          response = driver.send(:#{method}, path, params, default_headers.merge(headers))
+          unless driver.respond_to? :#{method}
+            raise UnsupportedMethodError, "Your driver does not support #{method.upcase} method"
+          end
+
+          response = driver.#{method}(path, params, default_headers.merge(headers))
           parsed_response = parse_response(response)
           yield parsed_response if block_given?
           parsed_response
-        rescue NoMethodError
-          raise UnsupportedMethodError, "Your driver does not support #{method.upcase} method"
         end
       RUBY
     end
 
     protected
-
     def app
       @options[:app] || Bbq.app
     end

--- a/test/dummy/app/controllers/home_controller.rb
+++ b/test/dummy/app/controllers/home_controller.rb
@@ -22,4 +22,8 @@ class HomeController < ApplicationController
       format.yaml { render :text => @rainbow.to_yaml }
     end
   end
+
+  def uh_oh
+    raise NoMethodError
+  end
 end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -5,4 +5,5 @@ Dummy::Application.routes.draw do
   match "/miracle" => "home#miracle"
   match "/ponycorns" => "home#ponycorns"
   match "/rainbow" => "home#rainbow"
+  match "/uh_oh" => "home#uh_oh"
 end

--- a/test/unit/bbq_test_unit_test.rb
+++ b/test/unit/bbq_test_unit_test.rb
@@ -136,6 +136,13 @@ class BbqTestUnitTest < Test::Unit::TestCase
           assert_equal 7, response.body["colors"]
         end
 
+        scenario 'client should propagate errors from the app' do
+          assert_raise NoMethodError do
+            client = Bbq::TestClient.new
+            client.get "/uh_oh"
+          end
+        end
+
         scenario 'client using driver with unsupported method' do
           class CustomDriverClient < Bbq::TestClient
             def driver
@@ -152,7 +159,7 @@ class BbqTestUnitTest < Test::Unit::TestCase
     TESTUNIT
 
     run_cmd 'ruby -Ilib -Itest/dummy/test test/dummy/test/acceptance/api_test.rb'
-    assert_match /5 tests, \d+ assertions, 0 failures, 0 errors/, output
+    assert_match /\d+ tests, \d+ assertions, 0 failures, 0 errors/, output
   end
 
   def test_session_pool


### PR DESCRIPTION
When `NoMethodError` was raised in the controller, `Bbq::TestClient` used to capture it and to throw unsupported method exception. This behavior is misleading and obscures the original issue, because the original backtrace is lost.
